### PR TITLE
GitHub Actions now uses KeyVault

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
       with:
         azcliversion: 2.3.1
         inlineScript: |
+          az group list --query "[?name=='terraformsa']" | jq '.[].properties.provisioningState'
           az group list --query "[?name=='disneydemo2']" | jq '.[].properties.provisioningState'
           az vm list --query "[?name=='debianvm']" | jq '.[].provisioningState'
           az aks list --query "[?name=='aksdemoapril']" | jq '.[].provisioningState'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,60 +9,68 @@ env:
   tf_working_dir: './terraform'
   tf_actions_version: 0.12.24
 jobs:
-  # terraform:
-  #   name: 'Terraform'
-  #   runs-on: ubuntu-18.04
-  #   steps:      
-  #   - name: 'Checkout'
-  #     uses: actions/checkout@v2
-  #   - name: 'Terraform Format'
-  #     uses: hashicorp/terraform-github-actions@master
-  #     with:
-  #       tf_actions_version: ${{ env.tf_actions_version }}
-  #       tf_actions_subcommand: 'fmt'
-  #       tf_actions_working_dir: ${{ env.tf_working_dir }}
-  #       tf_actions_comment: true
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   - name: 'Terraform Init'
-  #     uses: hashicorp/terraform-github-actions@master
-  #     with:
-  #       tf_actions_version: ${{ env.tf_actions_version }}
-  #       tf_actions_subcommand: 'init'
-  #       tf_actions_working_dir: ${{ env.tf_working_dir }}
-  #       tf_actions_comment: true
-  #       args: -backend-config=client_id="${{ secrets.CLIENT_ID  }}" -backend-config=client_secret="${{ secrets.CLIENT_SECRET  }}" -backend-config=tenant_id="${{ secrets.TENANT_ID  }}" -backend-config=subscription_id="${{ secrets.SUBSCRIPTION_ID  }}" 
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   - name: 'Terraform Validate'
-  #     uses: hashicorp/terraform-github-actions@master
-  #     with:
-  #       tf_actions_version: ${{ env.tf_actions_version }}
-  #       tf_actions_subcommand: 'validate'
-  #       tf_actions_working_dir: ${{ env.tf_working_dir }}
-  #       tf_actions_comment: true
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   - name: 'Terraform Plan'
-  #     uses: hashicorp/terraform-github-actions@master
-  #     with:
-  #       tf_actions_version: ${{ env.tf_actions_version }}
-  #       tf_actions_subcommand: 'plan'
-  #       tf_actions_working_dir: ${{ env.tf_working_dir }}
-  #       tf_actions_comment: true
-  #       args: -var=client_secret="${{ secrets.CLIENT_SECRET }}" -var=client_id="${{ secrets.CLIENT_ID }}" -var=subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var=tenant_id="${{ secrets.TENANT_ID }}"
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   - name: 'Terraform Apply'
-  #     uses: hashicorp/terraform-github-actions@master
-  #     with:
-  #       tf_actions_version: ${{ env.tf_actions_version }}
-  #       tf_actions_subcommand: 'apply'
-  #       tf_actions_working_dir: ${{ env.tf_working_dir }}
-  #       tf_actions_comment: true
-  #       args: -var=client_secret="${{ secrets.CLIENT_SECRET }}" -var=client_id="${{ secrets.CLIENT_ID }}" -var=subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var=tenant_id="${{ secrets.TENANT_ID }}"
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-18.04
+    steps:      
+    - name: 'Checkout'
+      uses: actions/checkout@v2
+    - uses: Azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+    - uses: Azure/get-keyvault-secrets@v1.0
+      with:
+        keyvault: "chizerkeys"
+        secrets: 'CLIENT-ID, CLIENT-SECRET, SUBSCRIPTION-ID, TENANT-ID'
+      id: myGetSecretAction
+    - name: 'Terraform Format'
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: ${{ env.tf_actions_version }}
+        tf_actions_subcommand: 'fmt'
+        tf_actions_working_dir: ${{ env.tf_working_dir }}
+        tf_actions_comment: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: 'Terraform Init'
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: ${{ env.tf_actions_version }}
+        tf_actions_subcommand: 'init'
+        tf_actions_working_dir: ${{ env.tf_working_dir }}
+        tf_actions_comment: true
+        args: -backend-config=client_id="${{ steps.myGetSecretAction.outputs.CLIENT-ID  }}" -backend-config=client_secret="${{ steps.myGetSecretAction.outputs.CLIENT-SECRET  }}" -backend-config=tenant_id="${{ steps.myGetSecretAction.outputs.TENANT-ID  }}" -backend-config=subscription_id="${{ steps.myGetSecretAction.outputs.SUBSCRIPTION-ID  }}" 
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: 'Terraform Validate'
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: ${{ env.tf_actions_version }}
+        tf_actions_subcommand: 'validate'
+        tf_actions_working_dir: ${{ env.tf_working_dir }}
+        tf_actions_comment: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: 'Terraform Plan'
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: ${{ env.tf_actions_version }}
+        tf_actions_subcommand: 'plan'
+        tf_actions_working_dir: ${{ env.tf_working_dir }}
+        tf_actions_comment: true
+        args: -var=client_secret="${{ steps.myGetSecretAction.outputs.CLIENT-SECRET }}" -var=client_id="${{ steps.myGetSecretAction.outputs.CLIENT-ID }}" -var=subscription_id="${{ steps.myGetSecretAction.outputs.SUBSCRIPTION-ID }}" -var=tenant_id="${{ steps.myGetSecretAction.outputs.TENANT-ID }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: 'Terraform Apply'
+      uses: hashicorp/terraform-github-actions@master
+      with:
+        tf_actions_version: ${{ env.tf_actions_version }}
+        tf_actions_subcommand: 'apply'
+        tf_actions_working_dir: ${{ env.tf_working_dir }}
+        tf_actions_comment: true
+        args: -var=client_secret="${{ steps.myGetSecretAction.outputs.CLIENT-SECRET }}" -var=client_id="${{ steps.myGetSecretAction.outputs.CLIENT-ID }}" -var=subscription_id="${{ steps.myGetSecretAction.outputs.SUBSCRIPTION-ID }}" -var=tenant_id="${{ steps.myGetSecretAction.outputs.TENANT-ID }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   terraformcheck:
     #needs: terraform

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
   #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   terraformcheck:
-    needs: terraform
+    #needs: terraform
     name: 'AZ CLI'
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,9 +69,16 @@ jobs:
     name: 'AZ CLI'
     runs-on: ubuntu-18.04
     steps:
-    - uses: azure/login@v1
+    - name: Azure login  
+      uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
+    - name: Azure CLI check
+      uses: azure/CLI@v1
+      with:
+        azcliversion: 2.3.1
+        inlineScript: |
+          az group list --query "[?name=='disneydemo2']" | jq '.[].properties.provisioningState'
+          az vm list --query "[?name=='debianvm']" | jq '.[].provisioningState'
+          az aks list --query "[?name=='aksdemoapril']" | jq '.[].provisioningState'
 
-    - run: |
-        az group list --query "[?name=='disneydemo2']" | jq '.[].properties.provisioningState'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,60 +9,60 @@ env:
   tf_working_dir: './terraform'
   tf_actions_version: 0.12.24
 jobs:
-  terraform:
-    name: 'Terraform'
-    runs-on: ubuntu-18.04
-    steps:      
-    - name: 'Checkout'
-      uses: actions/checkout@v2
-    - name: 'Terraform Format'
-      uses: hashicorp/terraform-github-actions@master
-      with:
-        tf_actions_version: ${{ env.tf_actions_version }}
-        tf_actions_subcommand: 'fmt'
-        tf_actions_working_dir: ${{ env.tf_working_dir }}
-        tf_actions_comment: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: 'Terraform Init'
-      uses: hashicorp/terraform-github-actions@master
-      with:
-        tf_actions_version: ${{ env.tf_actions_version }}
-        tf_actions_subcommand: 'init'
-        tf_actions_working_dir: ${{ env.tf_working_dir }}
-        tf_actions_comment: true
-        args: -backend-config=client_id="${{ secrets.CLIENT_ID  }}" -backend-config=client_secret="${{ secrets.CLIENT_SECRET  }}" -backend-config=tenant_id="${{ secrets.TENANT_ID  }}" -backend-config=subscription_id="${{ secrets.SUBSCRIPTION_ID  }}" 
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: 'Terraform Validate'
-      uses: hashicorp/terraform-github-actions@master
-      with:
-        tf_actions_version: ${{ env.tf_actions_version }}
-        tf_actions_subcommand: 'validate'
-        tf_actions_working_dir: ${{ env.tf_working_dir }}
-        tf_actions_comment: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: 'Terraform Plan'
-      uses: hashicorp/terraform-github-actions@master
-      with:
-        tf_actions_version: ${{ env.tf_actions_version }}
-        tf_actions_subcommand: 'plan'
-        tf_actions_working_dir: ${{ env.tf_working_dir }}
-        tf_actions_comment: true
-        args: -var=client_secret="${{ secrets.CLIENT_SECRET }}" -var=client_id="${{ secrets.CLIENT_ID }}" -var=subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var=tenant_id="${{ secrets.TENANT_ID }}"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: 'Terraform Apply'
-      uses: hashicorp/terraform-github-actions@master
-      with:
-        tf_actions_version: ${{ env.tf_actions_version }}
-        tf_actions_subcommand: 'apply'
-        tf_actions_working_dir: ${{ env.tf_working_dir }}
-        tf_actions_comment: true
-        args: -var=client_secret="${{ secrets.CLIENT_SECRET }}" -var=client_id="${{ secrets.CLIENT_ID }}" -var=subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var=tenant_id="${{ secrets.TENANT_ID }}"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # terraform:
+  #   name: 'Terraform'
+  #   runs-on: ubuntu-18.04
+  #   steps:      
+  #   - name: 'Checkout'
+  #     uses: actions/checkout@v2
+  #   - name: 'Terraform Format'
+  #     uses: hashicorp/terraform-github-actions@master
+  #     with:
+  #       tf_actions_version: ${{ env.tf_actions_version }}
+  #       tf_actions_subcommand: 'fmt'
+  #       tf_actions_working_dir: ${{ env.tf_working_dir }}
+  #       tf_actions_comment: true
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   - name: 'Terraform Init'
+  #     uses: hashicorp/terraform-github-actions@master
+  #     with:
+  #       tf_actions_version: ${{ env.tf_actions_version }}
+  #       tf_actions_subcommand: 'init'
+  #       tf_actions_working_dir: ${{ env.tf_working_dir }}
+  #       tf_actions_comment: true
+  #       args: -backend-config=client_id="${{ secrets.CLIENT_ID  }}" -backend-config=client_secret="${{ secrets.CLIENT_SECRET  }}" -backend-config=tenant_id="${{ secrets.TENANT_ID  }}" -backend-config=subscription_id="${{ secrets.SUBSCRIPTION_ID  }}" 
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   - name: 'Terraform Validate'
+  #     uses: hashicorp/terraform-github-actions@master
+  #     with:
+  #       tf_actions_version: ${{ env.tf_actions_version }}
+  #       tf_actions_subcommand: 'validate'
+  #       tf_actions_working_dir: ${{ env.tf_working_dir }}
+  #       tf_actions_comment: true
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   - name: 'Terraform Plan'
+  #     uses: hashicorp/terraform-github-actions@master
+  #     with:
+  #       tf_actions_version: ${{ env.tf_actions_version }}
+  #       tf_actions_subcommand: 'plan'
+  #       tf_actions_working_dir: ${{ env.tf_working_dir }}
+  #       tf_actions_comment: true
+  #       args: -var=client_secret="${{ secrets.CLIENT_SECRET }}" -var=client_id="${{ secrets.CLIENT_ID }}" -var=subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var=tenant_id="${{ secrets.TENANT_ID }}"
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   - name: 'Terraform Apply'
+  #     uses: hashicorp/terraform-github-actions@master
+  #     with:
+  #       tf_actions_version: ${{ env.tf_actions_version }}
+  #       tf_actions_subcommand: 'apply'
+  #       tf_actions_working_dir: ${{ env.tf_working_dir }}
+  #       tf_actions_comment: true
+  #       args: -var=client_secret="${{ secrets.CLIENT_SECRET }}" -var=client_id="${{ secrets.CLIENT_ID }}" -var=subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var=tenant_id="${{ secrets.TENANT_ID }}"
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   terraformcheck:
     needs: terraform

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,7 @@ jobs:
   terraform:
     name: 'Terraform'
     runs-on: ubuntu-18.04
-    steps:
-    # - uses: azure/login@v1
-    #   with:
-    #     creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-    # - run: |
-    #     az account list -o table
-       
+    steps:      
     - name: 'Checkout'
       uses: actions/checkout@v2
     - name: 'Terraform Format'
@@ -70,3 +63,15 @@ jobs:
         args: -var=client_secret="${{ secrets.CLIENT_SECRET }}" -var=client_id="${{ secrets.CLIENT_ID }}" -var=subscription_id="${{ secrets.SUBSCRIPTION_ID }}" -var=tenant_id="${{ secrets.TENANT_ID }}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  terraformcheck:
+    needs: terraform
+    name: 'AZ CLI'
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - run: |
+        az group list --query "[?name=='disneydemo2']" | jq '.[].properties.provisioningState'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![Terraform GitHub Actions](https://github.com/justin-chizer/terraform-aks/workflows/Terraform%20GitHub%20Actions/badge.svg?branch=master)
 # terraform-aks
 Upskilling in Terraform and GitHub Actions
 


### PR DESCRIPTION
Azure Credentials in GitHub have Reader access on the KeyVault rg and the KeyVault data plane and pulls the Service Principal with Contributor access on the subscription.